### PR TITLE
Make it possible to use tags formatted as yaml

### DIFF
--- a/pelican/plugins/tests/fixtures/external_link.md
+++ b/pelican/plugins/tests/fixtures/external_link.md
@@ -1,0 +1,1 @@
+[external](https://example.com)

--- a/pelican/plugins/tests/fixtures/internal_link.md
+++ b/pelican/plugins/tests/fixtures/internal_link.md
@@ -1,0 +1,5 @@
+---
+title: internal link
+---
+
+[[tags]]

--- a/pelican/plugins/tests/fixtures/other_list_type.md
+++ b/pelican/plugins/tests/fixtures/other_list_type.md
@@ -1,0 +1,10 @@
+---
+Status: published
+other:
+    - python
+    - code-formatter
+    - black
+Summary: Testing tags.
+---
+
+Some text here.

--- a/pelican/plugins/tests/fixtures/tags.md
+++ b/pelican/plugins/tests/fixtures/tags.md
@@ -1,0 +1,11 @@
+---
+title: tags
+Status: published
+tags:
+    - python
+    - code-formatter
+    - black
+Summary: Testing tags.
+---
+
+Some text here.

--- a/pelican/plugins/tests/fixtures/tags_comma.md
+++ b/pelican/plugins/tests/fixtures/tags_comma.md
@@ -1,0 +1,7 @@
+---
+Status: published
+tags: python,code-formatter,black
+Summary: Testing tags.
+---
+
+Some text here.

--- a/pelican/plugins/tests/test_obsidian_plugin.py
+++ b/pelican/plugins/tests/test_obsidian_plugin.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pytest
+from pelican.plugins.obsidian import ObsidianMarkdownReader  # noqa
+
+
+@pytest.fixture
+def obsidian(path):
+    omr = ObsidianMarkdownReader(
+        settings={
+            "MARKDOWN": {
+                "extensions": [
+                    "markdown.extensions.extra",
+                    "markdown.extensions.meta",
+                ]
+            },
+            "FORMATTED_FIELDS": ["summary"],
+        }
+    )
+    cwd = Path.cwd()
+    source_path = cwd / "pelican" / "plugins" / "tests" / f"fixtures/{path}.md"
+    obsidian = omr.read(source_path)
+    return obsidian
+
+
+@pytest.mark.parametrize('path', ["tags"])
+def test_tags_works_correctly(obsidian):
+    """Tags formatted as yaml list works properly"""
+    content, meta = obsidian
+    tags = meta["tags"]
+
+    assert 'Some text here' in content
+    assert len(tags) == 3
+
+
+@pytest.mark.parametrize('path', ["tags_comma"])
+def test_tags_works_pelican_way(obsidian):
+    """Test normal tags"""
+    content, meta = obsidian
+
+    assert 'Some text here' in content
+    assert len(meta["tags"]) == 3
+
+
+@pytest.mark.parametrize('path', ["other_list_type"])
+def test_other_list_property(obsidian):
+    """List is preserved for other list type property"""
+    content, meta = obsidian
+
+    assert 'Some text here' in content
+    assert len(meta["other"]) == 4
+
+
+@pytest.mark.parametrize('path', ["internal_link"])
+def test_internal_link_not_seen_in_article(obsidian):
+    """
+    If linked article has not been processed earlier
+    content is not linked.
+    """
+    content, meta = obsidian
+    assert '<p>tags</p>' == content
+
+
+@pytest.mark.parametrize('path', ["internal_link"])
+def test_external_link(obsidian):
+    """Able to use normal markdown links which renders properly"""
+    content, meta = obsidian
+    assert '<a href="https://example.com">external</a>'
+
+
+def test_with_generator():
+    pass


### PR DESCRIPTION
fix #5 Fixes the issue where tags are not formatted correctly because they are in yaml format. Also adds tests. 